### PR TITLE
Prevent ArrayIndexOutOfBoundsException

### DIFF
--- a/common/MysticWorld/Items/ItemBushFruit.java
+++ b/common/MysticWorld/Items/ItemBushFruit.java
@@ -33,7 +33,7 @@ public class ItemBushFruit extends ItemFood {
 	@Override
 	@SideOnly(Side.CLIENT)
 	public Icon getIconFromDamage(int meta) {
-		int j = MathHelper.clamp_int(meta, 0, FRUIT_TYPES.length);
+		int j = MathHelper.clamp_int(meta, 0, FRUIT_TYPES.length - 1);
 		return icons[j];
 	}
 


### PR DESCRIPTION
Tiny fix to ensure the icon ID is always within the correct bounds, to prevent crashes.

Fixes #7 
